### PR TITLE
Add Tag and AutoReveal commands

### DIFF
--- a/src/Commands/CommandsFactory.ts
+++ b/src/Commands/CommandsFactory.ts
@@ -1,6 +1,8 @@
 import { Header } from "./allCommands/Header";
 import { PageRef } from "./allCommands/PageRef";
 import { Remember } from "./allCommands/Remember";
+import { Tag } from "./allCommands/Tag";
+import { AutoReveal } from "./allCommands/AutoReveal";
 
 export class CommandsFactory {
     static Make(commandNameOrShortcut: string, commandArgument: string | null) {
@@ -20,10 +22,15 @@ export class CommandsFactory {
             case '+':
             case 'remember':
                 return new Remember(commandArgument);
+            case '#':
+            case 'tag':
+                return new Tag(commandArgument || "");
+            case '@':
+            case 'auto_reveal':
+                return new AutoReveal();
             case 'h1':
             case 'example':
             case 'recap':
-            case 'tag':
                 return new Header(1);
         }
     }

--- a/src/Commands/allCommands/AutoReveal.ts
+++ b/src/Commands/allCommands/AutoReveal.ts
@@ -1,0 +1,9 @@
+export class AutoReveal {
+    public toJson(): object {
+        return {
+            name: "AutoReveal",
+            vueComponent: null,
+            autoReveal: true,
+        };
+    }
+}

--- a/src/Commands/allCommands/Tag.ts
+++ b/src/Commands/allCommands/Tag.ts
@@ -1,0 +1,17 @@
+import VueTag from "../allCommandsComponent/VueTag.vue";
+
+export class Tag {
+    public tag: string;
+
+    constructor(tag: string) {
+        this.tag = tag;
+    }
+
+    public toJson(): object {
+        return {
+            name: "Tag",
+            vueComponent: VueTag,
+            tag: this.tag,
+        };
+    }
+}

--- a/src/Commands/allCommandsComponent/VueTag.vue
+++ b/src/Commands/allCommandsComponent/VueTag.vue
@@ -1,0 +1,34 @@
+<template>
+    <span class="tag">#{{ tag }}</span>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+
+interface Props {
+    config: any;
+}
+const props = defineProps<Props>();
+
+const tag = ref<string>('');
+
+const configureFromJson = (settings: any) => {
+    tag.value = settings.tag || '';
+};
+
+onMounted(() => {
+    configureFromJson(props.config);
+});
+</script>
+
+<style scoped>
+.tag {
+    display: inline-block;
+    padding: 2px 6px;
+    margin-right: 4px;
+    background-color: rgba(0, 0, 0, 0.1);
+    border-radius: 4px;
+    font-size: 12px;
+    font-family: "JetBrains Mono", monospace;
+}
+</style>


### PR DESCRIPTION
## Summary
- implement Tag and AutoReveal command classes
- create Vue component to render tags
- update CommandsFactory to recognise new commands

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687411618d10832ca360c172e7d0b3cc