### PR TITLE
Implement simple spaced repetition

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -14,6 +14,8 @@ interface Flashcard {
     pageRef: number;
     reviewedAt: Date;
     ease: number;
+    interval: number;
+    learningPhase: boolean;
     subParts: any[];
     [key: string]: any;
 }

--- a/src/FlashcardParser/FlashcardsParser.ts
+++ b/src/FlashcardParser/FlashcardsParser.ts
@@ -105,6 +105,8 @@ function parseCards(lineDescriptor: LineDescriptor, studySet: IStudySet): void {
                 now.getTime() - randomHours * 60 * 60 * 1000 - randomMinutes * 60 * 1000
             ),
             ease: 230,
+            interval: 0,
+            learningPhase: true,
         };
         if (command) {
             card.subParts.push({ ...command.toJson(), subParts: [] });

--- a/src/components/Flashcards/Flashcard.vue
+++ b/src/components/Flashcards/Flashcard.vue
@@ -4,7 +4,7 @@ import { createApp, ref, computed, onMounted } from 'vue'
 
 const emit = defineEmits<{
   reveal: [flashcard: any]
-  hide: [payload: { flashcard: any; hiding: boolean }]
+  hide: [payload: { flashcard: any; recall: string }]
 }>()
 
 const props = defineProps<{
@@ -37,13 +37,13 @@ function reveal() {
   emit('reveal', props.flashcard)
 }
 
-function hide(fromAction = false) {
+function hide(recall = 'hide') {
   hidingRecallOptions.value = true
   setTimeout(() => {
     revealed.value = false
     hidingRecallOptions.value = false
     props.flashcard.reviewedAt = new Date()
-    emit('hide', { flashcard: props.flashcard, hiding: !fromAction })
+    emit('hide', { flashcard: props.flashcard, recall })
   }, 300)
 }
 
@@ -100,7 +100,7 @@ defineExpose({ isRevealed, reveal, hide, forgot, bad, notBad, ok, point })
             <div ref="subparts" id="subparts"></div>
         </div>
         <RecallOptions v-else ref="recallOptions" class="buttons-container" :class="{ hiding: hidingRecallOptions }"
-            @optionSelected="option => hide(option !== 'hide')" />
+            @optionSelected="option => hide(option)" />
     </div>
 </template>
 

--- a/src/components/Flashcards/StudySet.vue
+++ b/src/components/Flashcards/StudySet.vue
@@ -80,9 +80,22 @@ const reveal = (flashcard: any) => {
 
 const updateCards = (flashcardObj: any) => {
     console.log(JSON.stringify(flashcardObj));
-    const { flashcard, hiding } = flashcardObj;
+    const { flashcard, recall } = flashcardObj;
 
-    if (!flashcard || hiding) return;
+    if (!flashcard || recall === 'hide') return;
+
+    const grades: Record<string, number> = {
+        'forgot': 0,
+        'bad': 1,
+        'not bad': 2,
+        'ok': 3,
+    };
+
+    const res = FlashcardsScheduler.nextInterval(grades[recall] ?? 0, flashcard.interval, flashcard.ease);
+    flashcard.interval = res.interval;
+    flashcard.ease = res.ease;
+    flashcard.learningPhase = false;
+    flashcard.reviewedAt = new Date(Date.now() + flashcard.interval * 24 * 60 * 60 * 1000);
 
     const n = props.flashcards.filter((f: any) => f !== undefined).length;
     if (n === 0) {

--- a/src/flashcardsScheduler.js
+++ b/src/flashcardsScheduler.js
@@ -47,6 +47,27 @@ export default class FlashcardsScheduler {
     return Math.random() * 0.1 + 0.95; // Random noise between 0.95 and 1.05
   }
 
-  static nextInterval(learningPhase, retrievalSuccess, currentInterval, ease) {
+  static nextInterval(retrievalSuccess, currentInterval = 0, ease = 250) {
+    const minEase = 130;
+    let newEase = ease;
+    let interval = currentInterval;
+
+    if (retrievalSuccess === 0) {
+      interval = 1;
+      newEase = Math.max(minEase, ease - 20);
+    } else if (retrievalSuccess === 1) {
+      interval = Math.max(1, currentInterval * 1.2);
+      newEase = Math.max(minEase, ease - 15);
+    } else if (retrievalSuccess === 2) {
+      interval = currentInterval * (ease / 100);
+    } else if (retrievalSuccess === 3) {
+      newEase = ease + 15;
+      interval = currentInterval * (ease / 100) * 1.3;
+    }
+
+    interval = interval * FlashcardsScheduler.intervalNoise();
+    interval = Math.min(Math.round(interval), 1825);
+
+    return { interval, ease: newEase };
   }
 }


### PR DESCRIPTION
## Summary
- implement `nextInterval` in flashcards scheduler
- track interval and learning phase on cards
- emit recall option when hiding a flashcard
- compute next interval in StudySet update function
- expose new fields on `Flashcard` interface

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6874c147629c832cbb393bc0a90dfc50