### PR TITLE
Implement studyset save feature

### DIFF
--- a/src/FlashcardParser/FlashcardsParser.ts
+++ b/src/FlashcardParser/FlashcardsParser.ts
@@ -13,7 +13,7 @@ interface IFlashcard {
     headers: string[];
     text: string;
     subParts: ISubPart[];
-    reviewedAt: Date;
+    reviewedAt: Date | null;
     ease: number;
     interval: number;
     learningPhase: boolean;
@@ -35,6 +35,7 @@ export interface IStudySet {
     aliases: IAlias[];
     headers: IHeader[];
     studiedCards: number;
+    originalLines: string[];
 }
 
 interface LineDescriptor {
@@ -52,17 +53,19 @@ const categories = {
 } as const;
 
 export function parseStudyset(lines: string[]): IStudySet | null {
+    const original = lines.filter((l) => l.trim() !== "");
     const studySet: IStudySet = {
         title: "",
         flashcards: [],
         resources: [],
         aliases: [],
         headers: [],
-        studiedCards: 0
+        studiedCards: 0,
+        originalLines: [...original]
     };
 
     try {
-        lines = lines.filter((l) => l.trim() !== "");
+        lines = [...original];
         const categoriesValues = Object.values(categories);
         let category = "";
 

--- a/src/components/FileParser.vue
+++ b/src/components/FileParser.vue
@@ -47,7 +47,7 @@ function parseFileContent() {
     return
   }
 
-  const lines = fileContent.value.split('\n').filter((l) => l.trim() !== '')
+  const lines = fileContent.value.split('\n')
   console.log('Start studyset parsing')
   const studyset = parseStudyset(lines)
   if (studyset == null) {

--- a/src/components/Flashcards/StudySet.vue
+++ b/src/components/Flashcards/StudySet.vue
@@ -3,12 +3,9 @@
         <div class="header-section" v-if="!showingFlashcard">
             <h3>{{ studySet.title }}</h3>
             <h1>{{ headerBreadcrumb }}</h1>
-            <!-- <button @click="downloadSet" class="save-btn">
+            <button @click="downloadSet" class="save-btn">
                 Save
             </button>
-            <button  class="change-btn">
-                Change
-            </button> -->
         </div>
         <div class="cards-section">
             <div class="cards-section-row">
@@ -125,36 +122,25 @@ const updateCards = (flashcardObj: any) => {
 };
 
 const downloadSet = () => {
-    if (!props.flashcards || props.flashcards.length === 0) {
-        alert('No flashcards to download!');
+    if (!props.studySet || !props.studySet.originalLines) {
+        alert('No study set to save!');
         return;
     }
 
-    // Format flashcards data as text
-    let content = `[Title]\n${props.studySet.title}\n\n`;
+    const lines: string[] = [...props.studySet.originalLines];
+    const cardsSorted = [...props.flashcards].sort((a: any, b: any) => b.line - a.line);
 
-    content += `[Resources]\n`;
-    props.resources.forEach((resource: string) => {
-        content += `${resource}\n`;
-    });
-    content += '\n';
+    for (let i = 0; i < cardsSorted.length; i++) {
+        const card = cardsSorted[i];
+        if (!card.reviewedAt) continue;
 
-    content += `[Cards]\n`;
-    props.flashcards.forEach((card: any, index: number) => {
-        content += `${card.frontText} .. ${card.pageRef}\n\t\\reviewedAt ${card.reviewedAt}\n`;
-        if (card.alias) {
-            card.alias.forEach((alias: string) => {
-                content += `\t\\alias ${alias}\n`;
-            });
-        }
-        if (card.tag) {
-            card.tag.forEach((tag: string) => {
-                content += `\t\\tag ${tag}\n`;
-            });
-        }
-    });
+        const nextLine = i === 0 ? lines.length : cardsSorted[i - 1].line;
+        const command = `\t*** ${new Date(card.reviewedAt).toISOString()}, ${card.ease}, ${card.interval}, ${card.learningPhase}`;
+        lines.splice(nextLine, 0, command);
+    }
 
-    // Create and download the file
+    const content = lines.join('\n');
+
     const blob = new Blob([content], { type: 'text/plain' });
     const url = window.URL.createObjectURL(blob);
     const link = document.createElement('a');


### PR DESCRIPTION
## Summary
- capture original study set lines during parsing
- allow FileParser to pass raw lines to parser
- enable a Save button on StudySet and add download logic

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877520258bc832ca186d32564158d4a