### PR TITLE
feat: add flashcard text editor

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,7 +6,8 @@ import FileParser from './components/FileParser.vue'
 import PDFUploader from './components/PDFUploader.vue'
 import GestureRecognizer from './components/GestureRecognizer/GestureRecognizer.vue'
 import VoiceRecognizer from './components/VoiceRecognizer/VoiceRecognizer.vue'
-import { IStudySet } from './FlashcardParser/FlashcardsParser'
+import TextEditor from './components/TextEditor.vue'
+import { IStudySet, parseStudyset } from './FlashcardParser/FlashcardsParser'
 
 // Define types
 interface Flashcard {
@@ -33,6 +34,8 @@ const pdfCache = reactive<Record<string, string>>({})
 const isScrolled = ref<boolean>(false)
 const mousePosition = ref({ x: 0, y: 0 })
 const cardRevealed = ref<boolean>(false)
+const uploadedText = ref<string>('')
+const editorVisible = ref<boolean>(false)
 
 // Refs
 const studySetComponent = ref(null)
@@ -66,9 +69,28 @@ function cardHidden() {
   cardRevealed.value = false
 }
 
-function loadStudySet(newStudySet: IStudySet) {
+function loadStudySet(newStudySet: IStudySet, content: string) {
   studySet.value = newStudySet
+  uploadedText.value = content
   console.info(`Loaded study set: ${JSON.stringify(newStudySet, null, 2)}`)
+}
+
+function openEditor() {
+  editorVisible.value = true
+}
+
+function closeEditor() {
+  editorVisible.value = false
+}
+
+function saveEdited(content: string) {
+  uploadedText.value = content
+  const lines = content.split('\n')
+  const newSet = parseStudyset(lines)
+  if (newSet) {
+    studySet.value = newSet
+  }
+  editorVisible.value = false
 }
 
 function addToCache(item: FileUploadItem) {
@@ -169,6 +191,7 @@ onUnmounted(() => {
         <div class="navbar-buttons">
           <button class="nav-btn">PDF</button>
           <button class="nav-btn">Studysets</button>
+          <button class="nav-btn" v-if="studySet" @click="openEditor">Edit</button>
           <GestureRecognizer ref="gestureRecognizer" class=" nav-btn" @command-recognized="commandRecognized"
             @pointing-changed="highlightPointing" />
           <VoiceRecognizer class="nav-btn" @command-recognized="commandRecognized" />
@@ -198,6 +221,7 @@ onUnmounted(() => {
         </div>
       </div>
     </div>
+    <TextEditor v-if="editorVisible" :model-value="uploadedText" @close="closeEditor" @save="saveEdited" />
   </div>
 </template>
 

--- a/src/components/FileParser.vue
+++ b/src/components/FileParser.vue
@@ -3,7 +3,7 @@ import { ref } from 'vue'
 import { parseStudyset, IStudySet } from '@/FlashcardParser/FlashcardsParser'
 
 const emit = defineEmits<{
-  setUploaded: [studySet: IStudySet]
+  setUploaded: [studySet: IStudySet, content: string]
 }>()
 
 const fileContent = ref('')
@@ -54,7 +54,7 @@ function parseFileContent() {
     console.error('[parser] Fail')
   } else {
     console.log('[parser] Success')
-    emit('setUploaded', studyset)
+    emit('setUploaded', studyset, fileContent.value)
   }
 }
 </script>

--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+
+const props = defineProps<{ modelValue: string }>()
+const emit = defineEmits(['close', 'save'])
+
+const content = ref(props.modelValue)
+
+watch(
+  () => props.modelValue,
+  (val) => {
+    content.value = val
+  }
+)
+
+function save() {
+  emit('save', content.value)
+}
+</script>
+
+<template>
+  <div class="editor-overlay">
+    <div class="editor-modal">
+      <textarea v-model="content" class="editor-textarea"></textarea>
+      <div class="editor-actions">
+        <button class="nav-btn" @click="emit('close')">Close</button>
+        <button class="nav-btn" @click="save">Save</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.editor-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.editor-modal {
+  background: #fff;
+  padding: 1rem;
+  width: 80%;
+  height: 80%;
+  display: flex;
+  flex-direction: column;
+}
+
+.editor-textarea {
+  flex: 1;
+  width: 100%;
+  resize: none;
+  margin-bottom: 1rem;
+}
+
+.editor-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+</style>


### PR DESCRIPTION
## Summary
- add navbar edit button
- open modal text editor for uploaded flashcards
- emit uploaded file content for editing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Could not load src/commands/all/Header)*

------
https://chatgpt.com/codex/tasks/task_e_688cfdf8561c832c97000b4f286d0824