### PR TITLE
feat: add alias command

### DIFF
--- a/src/Commands/CommandsFactory.ts
+++ b/src/Commands/CommandsFactory.ts
@@ -5,11 +5,11 @@ import { Tag } from "./all/Tag";
 import { AutoReveal } from "./all/AutoReveal";
 
 export class CommandsFactory {
-    static Make(commandNameOrShortcut: string, commandArgument: string | null) {
+    static Make(commandNameOrShortcut: string, commandArgument: string | null, lineObject: any = null) {
         if (commandNameOrShortcut[0] === '\\') {
             commandNameOrShortcut = commandNameOrShortcut.slice(1);
         }
-        
+
         let p = commandNameOrShortcut.indexOf('(');
         if (p !== -1) {
             commandNameOrShortcut = commandNameOrShortcut.slice(0, p);
@@ -28,6 +28,14 @@ export class CommandsFactory {
             case '@':
             case 'auto_reveal':
                 return new AutoReveal();
+            case 'alias':
+                if (lineObject) {
+                    if (!lineObject.alias) {
+                        lineObject.alias = [];
+                    }
+                    lineObject.alias.push(commandArgument || "");
+                }
+                return null;
             case '^':
                 return new Header(commandArgument || 1);
             default:

--- a/src/FlashcardParser/FlashcardsParser.ts
+++ b/src/FlashcardParser/FlashcardsParser.ts
@@ -1,5 +1,5 @@
-import { Header } from "@/commands/all/Header";
-import { CommandsFactory } from "@/commands/CommandsFactory";
+import { Header } from "@/Commands/all/Header";
+import { CommandsFactory } from "@/Commands/CommandsFactory";
 
 const commentSymbol: string = '//'
 
@@ -18,6 +18,7 @@ interface IFlashcard {
     interval: number;
     learningPhase: boolean;
     nextReviewAt: Date;
+    alias?: string[];
 }
 
 interface ISubPart {
@@ -223,13 +224,12 @@ function parseCards(lineDescriptor: LineDescriptor, studySet: IStudySet): boolea
     // New card
     if (tabs === 0) {
         let text: string;
-        let command: any;
+        let pageArg: string | null = null;
 
         const pageSplit = line.split("..");
         if (pageSplit.length > 1) {
             text = pageSplit.slice(0, -1).join("..").trim();
-            const commandArgument = pageSplit[pageSplit.length - 1];
-            command = CommandsFactory.Make("..", commandArgument);
+            pageArg = pageSplit[pageSplit.length - 1];
         } else {
             text = line;
         }
@@ -263,8 +263,11 @@ function parseCards(lineDescriptor: LineDescriptor, studySet: IStudySet): boolea
             j--;
         }
 
-        if (command) {
-            card.subParts.push({ ...command.toJson(), subParts: [] });
+        if (pageArg !== null) {
+            const command = CommandsFactory.Make("..", pageArg, card);
+            if (command) {
+                card.subParts.push({ ...command.toJson(), subParts: [] });
+            }
         }
         studySet.flashcards.push(card);
         return true;
@@ -293,15 +296,16 @@ function parseCards(lineDescriptor: LineDescriptor, studySet: IStudySet): boolea
             subParts = lastSubPart.subParts;
         }
 
-        let command: any;
         const commandSeparator = line.indexOf(" ");
-        if (commandSeparator === -1) {
-            command = CommandsFactory.Make(line, null);
-        } else {
-            const commandName = line.slice(0, commandSeparator).trim();
-            const argument = line.slice(commandSeparator).trim();
-            command = CommandsFactory.Make(commandName, argument);
+        const commandName = commandSeparator === -1 ? line.trim() : line.slice(0, commandSeparator).trim();
+        const argument = commandSeparator === -1 ? null : line.slice(commandSeparator).trim();
+
+        if (commandName === 'alias') {
+            CommandsFactory.Make(commandName, argument, studySet.flashcards[studySet.flashcards.length - 1]);
+            return true;
         }
+
+        const command = CommandsFactory.Make(commandName, argument, null);
 
         if (!command) {
             console.error(`[studySet] Unrecognized command at line: "${line}"`);


### PR DESCRIPTION
## Summary
- allow CommandsFactory to mutate parser line object and support alias commands
- parse flashcards with optional aliases

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689257633060832c969f5d4aecb5ad25