### PR TITLE
feat: add support for multiple pdf resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test"
   },
   "dependencies": {
     "@vue-pdf-viewer/viewer": "^2.5.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -31,6 +31,7 @@ interface FileUploadItem {
 const pageToShow = ref<number>(1)
 const studySet = ref<IStudySet | null>(null)
 const pdfCache = reactive<Record<string, string>>({})
+const pdfToShow = ref<string>('')
 const isScrolled = ref<boolean>(false)
 const mousePosition = ref({ x: 0, y: 0 })
 const cardRevealed = ref<boolean>(false)
@@ -48,20 +49,25 @@ function showPage(flashcard: Flashcard | null) {
     return
   }
 
-  let pageRefNum = null;
+  let pageRefNum: number | null = null
+  let resourceAlias = studySet.value?.defaultResource || ''
   for (let component of (flashcard.subParts || [])) {
     if (component.name == 'pageref') {
-      pageRefNum = component.ref;
-      break;
+      pageRefNum = component.ref
+      if (component.resourceAlias) {
+        resourceAlias = component.resourceAlias
+      }
+      break
     }
   }
 
-  if (!pageRefNum) {
-    console.error('Revealed card has no page')
+  if (!pageRefNum || !resourceAlias) {
+    console.error('Revealed card has no page or resource')
     return
   }
 
   pageToShow.value = pageRefNum
+  pdfToShow.value = studySet.value?.resources[resourceAlias] || ''
   cardRevealed.value = true
 }
 
@@ -72,6 +78,7 @@ function cardHidden() {
 function loadStudySet(newStudySet: IStudySet, content: string) {
   studySet.value = newStudySet
   uploadedText.value = content
+  pdfToShow.value = newStudySet.resources[newStudySet.defaultResource] || ''
   console.info(`Loaded study set: ${JSON.stringify(newStudySet, null, 2)}`)
 }
 
@@ -211,7 +218,7 @@ onUnmounted(() => {
         <div v-if="studySet" class="pdf-section">
           <PDFUploader @file-selected="addToCache" />
           <PDFPreview v-show="cardRevealed" ref="PDF" :pageToShow="pageToShow"
-            :pdf-url="pdfCache[studySet.resources[0].trim()]" />
+            :pdf-url="pdfCache[pdfToShow]" />
         </div>
 
         <div class="flashcard-wrapper" :class="{ revealed: cardRevealed }">

--- a/src/Commands/all/PageRef.ts
+++ b/src/Commands/all/PageRef.ts
@@ -4,10 +4,21 @@ export class PageRef {
   public pageRef: number;
   public allPageRefs: number[];
   public pagesString: string;
+  public resourceAlias?: string;
 
   constructor(pageRef: string) {
-    this.pagesString = pageRef;
-    this.allPageRefs = this.parsePageRefs(pageRef?.toString() || '0');
+    let alias: string | undefined;
+    let pageString = pageRef;
+
+    const idx = pageRef.indexOf(':');
+    if (idx !== -1) {
+      alias = pageRef.slice(0, idx).trim();
+      pageString = pageRef.slice(idx + 1).trim();
+    }
+
+    this.pagesString = pageString;
+    this.resourceAlias = alias;
+    this.allPageRefs = this.parsePageRefs(pageString?.toString() || '0');
     this.pageRef = this.allPageRefs[0] || 0;
   }
 
@@ -44,7 +55,8 @@ export class PageRef {
       vueComponent: VuePagRef,
       ref: this.pageRef,
       allRefs: this.allPageRefs,
-      pagesString: this.pagesString
+      pagesString: this.pagesString,
+      resourceAlias: this.resourceAlias
     };
   }
 }
@@ -55,4 +67,5 @@ export interface IPageRef {
   ref: number;
   allRefs: number[];
   pagesString: string;
+  resourceAlias?: string;
 }

--- a/src/Commands/components/VuePagRef.vue
+++ b/src/Commands/components/VuePagRef.vue
@@ -14,7 +14,9 @@ const props = defineProps<Props>();
 const pages = ref<string>('');
 
 const configureFromJson = (settings: IPageRef) => {
-    pages.value = settings.pagesString || '';
+    pages.value = settings.resourceAlias
+        ? `${settings.resourceAlias}:${settings.pagesString || ''}`
+        : (settings.pagesString || '');
 };
 
 onMounted(() => {

--- a/src/FlashcardParser/FlashcardsParser.ts
+++ b/src/FlashcardParser/FlashcardsParser.ts
@@ -33,7 +33,8 @@ interface IAlias {
 export interface IStudySet {
     title: string;
     flashcards: IFlashcard[];
-    resources: string[];
+    resources: Record<string, string>;
+    defaultResource: string;
     aliases: IAlias[];
     headers: IHeader[];
     studiedCards: number;
@@ -59,7 +60,8 @@ export function parseStudyset(lines: string[]): IStudySet | null {
     const studySet: IStudySet = {
         title: "",
         flashcards: [],
-        resources: [],
+        resources: {},
+        defaultResource: "",
         aliases: [],
         headers: [],
         studiedCards: 0,
@@ -121,7 +123,26 @@ function parseCategory(
         return true;
     } else if (category === categories.resources) {
         console.log(`[parser] Reading resource '${trimmedLine}'`);
-        studySet.resources.push(trimmedLine);
+        const idx = trimmedLine.indexOf(':');
+        let alias: string;
+        let resource: string;
+
+        if (idx !== -1) {
+            alias = trimmedLine.slice(0, idx).trim();
+            resource = trimmedLine.slice(idx + 1).trim();
+        } else {
+            alias = trimmedLine.trim();
+            resource = alias;
+        }
+
+        if (!alias) {
+            return true;
+        }
+
+        studySet.resources[alias] = resource;
+        if (!studySet.defaultResource) {
+            studySet.defaultResource = alias;
+        }
         return true;
     } else if (category === categories.cards) {
         return parseCards(lineDescriptor, studySet);

--- a/src/components/FileParser.vue
+++ b/src/components/FileParser.vue
@@ -7,7 +7,6 @@ const emit = defineEmits<{
 }>()
 
 const fileContent = ref('')
-const resources = ref<string[]>([])
 const title = ref('')
 const flashcards = ref<any[]>([])
 const error = ref<string | null>(null)
@@ -20,7 +19,6 @@ function handleFileUpload(event: Event) {
   error.value = null
   fileContent.value = ''
   flashcards.value = []
-  resources.value = []
   title.value = ''
 
   const reader = new FileReader()

--- a/src/components/Flashcards/StudySet.vue
+++ b/src/components/Flashcards/StudySet.vue
@@ -6,7 +6,7 @@ import Flashcard from './Flashcard.vue';
 // Define props
 interface Props {
   flashcards: any[];
-  resources: string[];
+  resources: Record<string, string>;
   studySet: any;
 }
 

--- a/tests/unit/FlashcardsParser.test.js
+++ b/tests/unit/FlashcardsParser.test.js
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { transformSync } from 'esbuild';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '../../');
+
+function loadTs(modulePath, fromDir = projectRoot) {
+  let abs;
+  if (modulePath.startsWith('@/')) {
+    abs = path.join(projectRoot, 'src', modulePath.slice(2));
+  } else {
+    abs = path.resolve(fromDir, modulePath);
+  }
+  if (!abs.endsWith('.ts') && !abs.endsWith('.js')) {
+    abs += '.ts';
+  }
+  const ts = fs.readFileSync(abs, 'utf8');
+  const { code } = transformSync(ts, { loader: 'ts', format: 'cjs', target: 'es2019' });
+  const module = { exports: {} };
+  const requireFunc = (p) => {
+    if (p.endsWith('.vue')) {
+      return {};
+    }
+    return loadTs(p, path.dirname(abs));
+  };
+  const fn = new Function('require', 'module', 'exports', code);
+  fn(requireFunc, module, module.exports);
+  return module.exports;
+}
+
+const { parseStudyset } = loadTs('@/FlashcardParser/FlashcardsParser');
+const { PageRef } = loadTs('@/Commands/all/PageRef');
+
+test('parses resources with alias and path-only entries and sets default', () => {
+  const lines = `[Title]\nSet\n[Resources]\nalias1: path1.pdf\npath2.pdf\n[Cards]\nQ1 .. 1`.split('\n');
+  const study = parseStudyset(lines);
+  assert.deepEqual(study.resources, {
+    alias1: 'path1.pdf',
+    'path2.pdf': 'path2.pdf'
+  });
+  assert.equal(study.defaultResource, 'alias1');
+});
+
+test('PageRef extracts alias and pages string', () => {
+  const pr = new PageRef('alias1:1,2-4');
+  assert.equal(pr.resourceAlias, 'alias1');
+  assert.equal(pr.pagesString, '1,2-4');
+  assert.deepEqual(pr.allPageRefs, [1, 2, 3, 4]);
+});
+
+test('flashcard with aliased PageRef selects correct resource', () => {
+  const lines = `[Title]\nSet\n[Resources]\na1: r1.pdf\na2: r2.pdf\n[Cards]\nCard1 .. 1\nCard2 .. a2:2`.split('\n');
+  const study = parseStudyset(lines);
+  const card = study.flashcards[1];
+  const component = card.subParts.find((sp) => sp.name === 'pageref');
+  const alias = component.resourceAlias || study.defaultResource;
+  const chosen = study.resources[alias];
+  assert.equal(chosen, 'r2.pdf');
+  assert.equal(component.ref, 2);
+});


### PR DESCRIPTION
## Summary
- allow study sets to declare multiple PDF resources and a default
- enable `PageRef` command to target resources via `<alias>:page-list`
- load and display PDF based on page reference alias
- cover resource aliasing with Node-based parser tests

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68936e6bdf14832c9ee5d37eb58e3b3e