### PR TITLE
Ensure home page fits viewport and display study progress

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -117,7 +117,8 @@ const {
 .app-container {
   position: relative;
   min-height: 100vh;
-  width: 100vw;
+  width: 100%;
+  overflow-x: hidden;
   font-family: 'Inter', 'Segoe UI', sans-serif;
   display: flex;
   flex-direction: column;
@@ -227,12 +228,13 @@ const {
   gap: 2rem;
 }
 
+
 .progress-container {
   position: relative;
-  width: calc(100% - 2rem);
+  width: 100%;
   height: 3px;
   background-color: transparent;
-  margin: 0 1rem;
+  margin: 0;
   border-radius: 2px;
   overflow: hidden;
 }
@@ -246,7 +248,8 @@ const {
 .progress-label {
   position: absolute;
   top: -20px;
-  right: 0;
+  left: 50%;
+  transform: translateX(-50%);
   font-size: 0.75rem;
   font-weight: 500;
   color: #6b7280;
@@ -402,8 +405,8 @@ const {
 
   .progress-container {
     height: 2px;
-    margin: 0 0.5rem;
-    width: calc(100% - 1rem);
+    margin: 0;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
- Prevent horizontal scrolling by constraining the app container to 100% width and hiding overflow.
- Expand progress bar to full width and center a label showing studied vs total flashcards.
- Adjust responsive styles for the progress bar.

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'eslint-plugin-vue')*

------
https://chatgpt.com/codex/tasks/task_e_689fbd2601d8832c82d5ae84acac6955