### PR TITLE
feat: add shuffle wheel for study sets

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -6,6 +6,7 @@ import PDFUploader from '../components/PDFUploader.vue'
 import GestureRecognizer from '../components/GestureRecognizer/GestureRecognizer.vue'
 import VoiceRecognizer from '../components/VoiceRecognizer/VoiceRecognizer.vue'
 import TextEditor from '../components/TextEditor.vue'
+import ShuffleMenu from '../components/ShuffleMenu.vue'
 import { useApp } from './useApp'
 
 const {
@@ -35,6 +36,14 @@ const {
   studiedCards,
   progressPercent
 } = useApp()
+
+const shuffleOriginalOrder = () => {
+  studySetComponent.value?.shuffleFlashcards('original')
+}
+
+const shuffleRandomOrder = () => {
+  studySetComponent.value?.shuffleFlashcards('random')
+}
 </script>
 
 
@@ -88,6 +97,7 @@ const {
       </div>
     </div>
     <TextEditor v-if="editorVisible" :model-value="uploadedText" @close="closeEditor" @save="saveEdited" />
+    <ShuffleMenu v-if="studySet" @order-original="shuffleOriginalOrder" @order-random="shuffleRandomOrder" />
   </div>
 </template>
 

--- a/src/components/Flashcards/StudySet.vue
+++ b/src/components/Flashcards/StudySet.vue
@@ -188,6 +188,22 @@ const point = (what: string) => {
   currentFlashcardObject.value?.point(what);
 }
 
+const shuffleFlashcards = (mode: 'original' | 'random') => {
+  if (mode === 'original') {
+    scheduler.value.randomizeNewCards = false;
+    props.flashcards.sort((a: any, b: any) => (a.line ?? 0) - (b.line ?? 0));
+  } else {
+    scheduler.value.randomizeNewCards = true;
+    props.flashcards.sort(() => Math.random() - 0.5);
+  }
+
+  scheduler.value.resetCards();
+  scheduler.value.addMoreFlashcards(props.flashcards);
+
+  const dueCards = scheduler.value.scheduleFlashcards();
+  studyCard.value = dueCards.length > 0 ? dueCards[0] : null;
+};
+
 const undoLastReview = () => {
   const last = reviewHistory.value.pop();
   if (!last) return;
@@ -256,7 +272,8 @@ onUnmounted(() => {
 defineExpose({
   revealCurrent,
   hideCurrent,
-  point
+  point,
+  shuffleFlashcards
 });
 </script>
 

--- a/src/components/ShuffleMenu.vue
+++ b/src/components/ShuffleMenu.vue
@@ -9,11 +9,27 @@ const toggleMenu = () => {
 
 <template>
   <div class="menu-container">
-    <button class="main-button" @click="toggleMenu">⚙️</button>
-    <div v-if="isOpen" class="options">
-      <button class="option" @click="$emit('order-original'); toggleMenu()">Orig</button>
-      <button class="option option-random" @click="$emit('order-random'); toggleMenu()">Rand</button>
-    </div>
+    <button class="main-button" @click="toggleMenu" :class="{ 'open': isOpen }">
+      ⚙️
+    </button>
+    <transition name="wheel">
+      <div v-if="isOpen" class="options-wheel">
+        <button 
+          class="option option-1" 
+          @click="$emit('order-original'); toggleMenu()"
+          title="Original Order"
+        >
+          Orig
+        </button>
+        <button 
+          class="option option-2" 
+          @click="$emit('order-random'); toggleMenu()"
+          title="Random Order"
+        >
+          Rand
+        </button>
+      </div>
+    </transition>
   </div>
 </template>
 
@@ -23,35 +39,160 @@ const toggleMenu = () => {
   bottom: 20px;
   left: 20px;
 }
+
 .main-button {
-  width: 56px;
-  height: 56px;
+  width: 60px;
+  height: 60px;
   border-radius: 50%;
   border: none;
-  background-color: #4b5563;
+  background: linear-gradient(135deg, #4b5563, #374151);
   color: #fff;
   cursor: pointer;
   font-size: 24px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  transition: all 0.3s ease;
+  position: relative;
+  z-index: 10;
 }
-.options {
+
+.main-button:hover {
+  transform: scale(1.1);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+}
+
+.main-button.open {
+  transform: rotate(180deg);
+  background: linear-gradient(135deg, #6366f1, #4f46e5);
+}
+
+.options-wheel {
   position: absolute;
-  bottom: 0;
-  left: 0;
+  bottom: 30px;
+  left: 30px;
+  width: 0;
+  height: 0;
 }
+
 .option {
   position: absolute;
-  width: 40px;
-  height: 40px;
+  width: 48px;
+  height: 48px;
   border-radius: 50%;
-  border: none;
-  background-color: #6b7280;
+  border: 2px solid rgba(255, 255, 255, 0.2);
+  background: linear-gradient(135deg, #6b7280, #4b5563);
   color: #fff;
   cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.3s ease;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.3);
+  transform-origin: center;
 }
-.option:first-of-type {
-  transform: translate(-60px, 0);
+
+.option:hover {
+  transform: scale(1.1);
+  background: linear-gradient(135deg, #8b5cf6, #7c3aed);
+  box-shadow: 0 4px 12px rgba(139, 92, 246, 0.4);
 }
-.option-random {
-  transform: translate(0, -60px);
+
+/* Position options in a circular pattern */
+.option-1 {
+  bottom: -24px;
+  left: -80px;
+  animation: slideIn1 0.3s ease-out;
 }
-</style>
+
+.option-2 {
+  bottom: 40px;
+  left: -24px;
+  animation: slideIn2 0.4s ease-out;
+}
+
+/* Animations for wheel opening */
+@keyframes slideIn1 {
+  from {
+    bottom: -24px;
+    left: -24px;
+    opacity: 0;
+    transform: scale(0);
+  }
+  to {
+    bottom: -24px;
+    left: -80px;
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes slideIn2 {
+  from {
+    bottom: -24px;
+    left: -24px;
+    opacity: 0;
+    transform: scale(0);
+  }
+  to {
+    bottom: 40px;
+    left: -24px;
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* Transition for the entire wheel */
+.wheel-enter-active, .wheel-leave-active {
+  transition: opacity 0.3s ease;
+}
+
+.wheel-enter-from, .wheel-leave-to {
+  opacity: 0;
+}
+
+/* Add ripple effect on click */
+.option:active {
+  transform: scale(0.95);
+}
+
+.main-button:active {
+  transform: scale(0.95) rotate(180deg);
+}
+
+/* Additional visual enhancements */
+.option::before {
+  content: '';
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  right: -2px;
+  bottom: -2px;
+  border-radius: 50%;
+  background: linear-gradient(45deg, transparent, rgba(255, 255, 255, 0.1), transparent);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.option:hover::before {
+  opacity: 1;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .main-button {
+    width: 56px;
+    height: 56px;
+    font-size: 20px;
+  }
+  
+  .option {
+    width: 44px;
+    height: 44px;
+    font-size: 11px;
+  }
+  
+  .option-1 {
+    left: -72px;
+  }
+}</style>

--- a/src/components/ShuffleMenu.vue
+++ b/src/components/ShuffleMenu.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const isOpen = ref(false);
+const toggleMenu = () => {
+  isOpen.value = !isOpen.value;
+};
+</script>
+
+<template>
+  <div class="menu-container">
+    <button class="main-button" @click="toggleMenu">⚙️</button>
+    <div v-if="isOpen" class="options">
+      <button class="option" @click="$emit('order-original'); toggleMenu()">Orig</button>
+      <button class="option option-random" @click="$emit('order-random'); toggleMenu()">Rand</button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.menu-container {
+  position: fixed;
+  bottom: 20px;
+  left: 20px;
+}
+.main-button {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  border: none;
+  background-color: #4b5563;
+  color: #fff;
+  cursor: pointer;
+  font-size: 24px;
+}
+.options {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+}
+.option {
+  position: absolute;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: none;
+  background-color: #6b7280;
+  color: #fff;
+  cursor: pointer;
+}
+.option:first-of-type {
+  transform: translate(-60px, 0);
+}
+.option-random {
+  transform: translate(0, -60px);
+}
+</style>

--- a/src/flashcardsScheduler.ts
+++ b/src/flashcardsScheduler.ts
@@ -27,6 +27,7 @@ export default class FlashcardsScheduler {
   easyIntervalOnExitingLearningMode: string;
   defaultDifficulty: number;
   maximumIntervals: number;
+  randomizeNewCards: boolean;
 
   constructor() {
     this.flashcards = [];
@@ -37,6 +38,7 @@ export default class FlashcardsScheduler {
     this.defaultDifficulty = 5;
     // Maximum allowed interval expressed in days
     this.maximumIntervals = 1825; // Days
+    this.randomizeNewCards = true;
   }
 
   resetCards(): void {
@@ -155,9 +157,13 @@ export default class FlashcardsScheduler {
         );
       }
 
-      // Priority 5: New cards (never reviewed) - add some randomness
+      // Priority 5: New cards (never reviewed)
       if (!aReviewed && !bReviewed) {
-        return Math.random() - 0.5; // Random order for new cards
+        if (this.randomizeNewCards) {
+          return Math.random() - 0.5; // Random order for new cards
+        }
+        // Preserve original order using line numbers
+        return (a.line ?? 0) - (b.line ?? 0);
       }
 
       return 0;


### PR DESCRIPTION
## Summary
- add floating shuffle menu in bottom left
- allow sorting flashcards in original order or random
- make scheduler capable of preserving flashcard order

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'eslint-plugin-vue'; attempted `npm install` but got 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9e1db2e4832c882729777e28173c